### PR TITLE
fix/gulp-resolve-paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ git clone git@github.com:mikkojamG/ui-component-library-proto.git
 
 Create `.env` file from the provided `.env.example` file. Fill in paths for environment variables `THEMES_ROOT` and `THEME_DIRECTORY` if they differ from the defaults.
 
-_Make sure that paths are relative to working theme._
-
 ### Imports
 
 Component library imports components to `components.less` file under the working theme directory. If the file does not exist, it will be created on install.

--- a/gulp-helpers.js
+++ b/gulp-helpers.js
@@ -1,8 +1,11 @@
 const fs = require('fs');
 const prompts = require('prompts');
+const path = require('path');
 
 const gulp = require('gulp');
 const clean = require('gulp-clean');
+
+const themeDirectoryPath = path.resolve(process.env.THEME_DIRECTORY);
 
 const cleanDir = (dir) => gulp.src(`${dir}/*`).pipe(clean({ force: true }));;
 
@@ -22,9 +25,9 @@ const symlinksExist = (paths) => {
 
 const checkForComponents = async () => {
   const sources = [
-    `${process.env.THEME_DIRECTORY}/templates/components`,
-    `${process.env.THEME_DIRECTORY}/less/components`,
-    `${process.env.THEME_DIRECTORY}/js/components`
+    `${themeDirectoryPath}/templates/components`,
+    `${themeDirectoryPath}/less/components`,
+    `${themeDirectoryPath}/js/components`
   ];
 
   if (componentsExist(sources) && !symlinksExist(sources)) {
@@ -43,9 +46,9 @@ const checkForComponents = async () => {
 
 const checkForSymlinks = async () => {
   const sources = [
-    `${process.env.THEME_DIRECTORY}/templates/components`,
-    `${process.env.THEME_DIRECTORY}/less/components`,
-    `${process.env.THEME_DIRECTORY}/js/components`
+    `${themeDirectoryPath}/templates/components`,
+    `${themeDirectoryPath}/less/components`,
+    `${themeDirectoryPath}/js/components`
   ];
 
   if (componentsExist(sources) && symlinksExist(sources)) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -54,7 +54,7 @@ const styles = () => {
     .src(`${source}/*.less`)
     .pipe(less({
       modifyVars: {
-        '@themePath': `${themesRootPath}`
+        '@themePath': themesRootPath
       }
     }))
     .pipe(autoprefixer())

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -165,7 +165,6 @@ const checkImportTargetFile = async (file) => new Promise((resolve, reject) => {
 
 const componentImports = async () => {
   const less = `${themeDirectoryPath}/less`;
-  const lessBase = `${path.parse(themeDirectoryPath).base}/less/`
 
   try {
     await checkImportTargetFile(`${less}/components.less`);
@@ -178,7 +177,7 @@ const componentImports = async () => {
           endtag: '/* Component imports end here */',
           addRootSlash: false,
           transform: (filepath) => {
-            const componentPath = filepath.split(lessBase)[1];
+            const componentPath = filepath.split('/less/')[1];
 
             return `@import "${componentPath}";`
           }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@ const shell = require('gulp-shell');
 const browserSync = require('browser-sync');
 const fs = require('fs');
 const chalk = require('chalk');
+const path = require('path');
 
 const autoprefixer = require('gulp-autoprefixer');
 const minify = require('gulp-clean-css');
@@ -16,6 +17,10 @@ const rename = require('gulp-rename');
 const concat = require('gulp-concat');
 const inject = require('gulp-inject');
 const replace = require('gulp-replace');
+
+const themesRootPath = path.resolve(process.env.THEMES_ROOT);
+const themeDirectoryPath = path.resolve(process.env.THEME_DIRECTORY);
+const componentsSourcePath = path.resolve(config.paths.source.patterns);
 
 // Tasks
 const cleanPublic = () => helpers.cleanDir(config.paths.public.root);
@@ -30,8 +35,8 @@ const patternLab = () => {
 gulp.task(patternLab);
 
 const fonts = () => {
-  const bootstrapFonts = `${process.env.THEMES_ROOT}/bootstrap3/css/fonts`;
-  const finnaFonts = `${process.env.THEME_DIRECTORY}/css/fonts`;
+  const bootstrapFonts = `${themesRootPath}/bootstrap3/css/fonts`;
+  const finnaFonts = `${themeDirectoryPath}/css/fonts`;
 
   const dest = config.paths.public.fonts;
 
@@ -49,7 +54,7 @@ const styles = () => {
     .src(`${source}/*.less`)
     .pipe(less({
       modifyVars: {
-        '@themePath': `../../../${process.env.THEMES_ROOT}`
+        '@themePath': `${themesRootPath}`
       }
     }))
     .pipe(autoprefixer())
@@ -159,7 +164,7 @@ const checkImportTargetFile = async (file) => new Promise((resolve, reject) => {
 
 
 const componentImports = async () => {
-  const less = `${process.env.THEME_DIRECTORY}/less`;
+  const less = `${themeDirectoryPath}/less`;
 
   try {
     await checkImportTargetFile(`${less}/components.less`);
@@ -170,7 +175,7 @@ const componentImports = async () => {
         {
           starttag: '/* Component imports start here */',
           endtag: '/* Component imports end here */',
-          ignorePath: `/${process.env.THEME_DIRECTORY}/less/`,
+          ignorePath: `/${themeDirectoryPath}/less/`,
           addRootSlash: false,
           transform: (filepath) => `@import "${filepath}";`
         }))
@@ -185,21 +190,21 @@ gulp.task(componentImports);
 const unlinkPatterns = () => {
   return gulp
     .src('.', { allowEmpty: true })
-    .pipe(shell([`rm -rf ${process.env.THEME_DIRECTORY}/templates/components`]))
+    .pipe(shell([`rm -rf ${themeDirectoryPath}/templates/components`]))
 };
 gulp.task(unlinkPatterns);
 
 const unlinkStyles = () => {
   return gulp
     .src('.', { allowEmpty: true })
-    .pipe(shell([`rm -rf ${process.env.THEME_DIRECTORY}/less/components`]))
+    .pipe(shell([`rm -rf ${themeDirectoryPath}/less/components`]))
 };
 gulp.task(unlinkStyles);
 
 const unlinkScripts = () => {
   return gulp
     .src('.', { allowEmpty: true })
-    .pipe(shell([`rm -rf ${process.env.THEME_DIRECTORY}/js/components`]))
+    .pipe(shell([`rm -rf ${themeDirectoryPath}/js/components`]))
 };
 gulp.task(unlinkScripts);
 
@@ -209,7 +214,7 @@ const symLinkPatterns = () => {
   return gulp
     .src('.', { allowEmpty: true })
     .pipe(shell([
-      `cd ${process.env.THEME_DIRECTORY}/templates && ln -fs ../../../../ui-component-library-proto/source/components`
+      `cd ${themeDirectoryPath}/templates && ln -fs ${componentsSourcePath}`
     ]));
 };
 gulp.task(symLinkPatterns);
@@ -217,14 +222,14 @@ gulp.task(symLinkPatterns);
 const symLinkStyles = () => {
   return gulp
     .src('.', { allowEmpty: true })
-    .pipe(shell([`cd ${process.env.THEME_DIRECTORY}/less && ln -fs ../../../../ui-component-library-proto/source/components`]));
+    .pipe(shell([`cd ${themeDirectoryPath}/less && ln -fs ${componentsSourcePath}`]));
 };
 gulp.task(symLinkStyles);
 
 const symLinkScripts = () => {
   return gulp
     .src('.', { allowEmpty: true })
-    .pipe(shell([`cd ${process.env.THEME_DIRECTORY}/js && ln -fs ../../../../ui-component-library-proto/source/components`]));
+    .pipe(shell([`cd ${themeDirectoryPath}/js && ln -fs ${componentsSourcePath}`]));
 };
 gulp.task(symLinkScripts);
 
@@ -252,7 +257,7 @@ const copyPatterns = () => {
 
   return gulp
     .src(`${source}**/*.phtml`)
-    .pipe(gulp.dest(`${process.env.THEME_DIRECTORY}/templates/components`));
+    .pipe(gulp.dest(`${themeDirectoryPath}/templates/components`));
 };
 gulp.task(copyPatterns);
 
@@ -261,7 +266,7 @@ const copyStyles = () => {
 
   return gulp
     .src(`${source}**/*.less`)
-    .pipe(gulp.dest(`${process.env.THEME_DIRECTORY}/less/components`));
+    .pipe(gulp.dest(`${themeDirectoryPath}/less/components`));
 };
 gulp.task(copyStyles);
 
@@ -270,7 +275,7 @@ const copyScripts = () => {
 
   return gulp
     .src(`${source}**/*.js`)
-    .pipe(gulp.dest(`${process.env.THEME_DIRECTORY}/js/components`));
+    .pipe(gulp.dest(`${themeDirectoryPath}/js/components`));
 };
 gulp.task(copyScripts);
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -165,6 +165,7 @@ const checkImportTargetFile = async (file) => new Promise((resolve, reject) => {
 
 const componentImports = async () => {
   const less = `${themeDirectoryPath}/less`;
+  const lessBase = `${path.parse(themeDirectoryPath).base}/less/`
 
   try {
     await checkImportTargetFile(`${less}/components.less`);
@@ -175,9 +176,12 @@ const componentImports = async () => {
         {
           starttag: '/* Component imports start here */',
           endtag: '/* Component imports end here */',
-          ignorePath: `/${themeDirectoryPath}/less/`,
           addRootSlash: false,
-          transform: (filepath) => `@import "${filepath}";`
+          transform: (filepath) => {
+            const componentPath = filepath.split(lessBase)[1];
+
+            return `@import "${componentPath}";`
+          }
         }))
       .pipe(gulp.dest(less));
   }


### PR DESCRIPTION
- Adding flexibility to where component library can be located on the work station. Achieving this by resolving all paths related to the working theme, thus they can be relative or absolute.
- Update README