### PR TITLE
feat/js-component-imports

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,6 @@ const browserSync = require('browser-sync');
 const fs = require('fs');
 const chalk = require('chalk');
 const exec = require('child_process').exec;
-const asyncExec = require('util').promisify(exec);
 const glob = require('glob');
 const path = require('path');
 
@@ -207,7 +206,7 @@ const checkImportTargetFile = async (file) => new Promise((resolve, reject) => {
 ;
 
 
-const themeStyleImports = async () => {
+const themeLessImports = async () => {
   const less = `${themeDirectoryPath}/less`;
 
   try {
@@ -232,7 +231,7 @@ const themeStyleImports = async () => {
     throw err;
   }
 };
-gulp.task(themeStyleImports);
+gulp.task(themeLessImports);
 
 const unlinkPatterns = () => {
   return exec(`rm -rf ${themeDirectoryPath}/templates/components`, (err) => {
@@ -306,7 +305,7 @@ const symLinkTheme = gulp.series(
   symLinkPatterns,
   symLinkStyles,
   symLinkScripts,
-  themeStyleImports,
+  themeLessImports,
   themeScriptImports
 );
 
@@ -353,7 +352,7 @@ const copyTheme = gulp.series(
   copyPatterns,
   copyStyles,
   copyScripts,
-  themeStyleImports,
+  themeLessImports,
   themeScriptImports
 );
 
@@ -379,7 +378,7 @@ vendorScripts.description = "Build and uglify vendor Javascript";
 
 watchTask.description = "Initialize BrowserSync instance and watch for changes";
 
-themeStyleImports.description = "Inject component Less imports to dedicated files";
+themeLessImports.description = "Inject component Less imports to dedicated files";
 
 themeScriptImports.description = "Inject component JS imports to working theme config";
 

--- a/package.json
+++ b/package.json
@@ -43,11 +43,11 @@
     "gulp-clean": "^0.4.0",
     "gulp-clean-css": "^4.3.0",
     "gulp-concat": "^2.6.1",
+    "gulp-exec": "^5.0.0",
     "gulp-inject": "^5.0.5",
     "gulp-less": "^4.0.1",
     "gulp-rename": "^2.0.0",
     "gulp-replace": "^1.0.0",
-    "gulp-shell": "^0.8.0",
     "gulp-uglify": "^3.0.2",
     "husky": "^4.2.5",
     "prompts": "^2.3.2"


### PR DESCRIPTION
Suggestion on how JS component imports could be done automatically. Basically on install task makes a copy of the current theme configuration, replaces component paths under `js` with fresh ones and replaces the whole theme config with a new one. Writing data back into theme config requires some ugly manual parsing but it's not too bad here.

Also got rid of `gulp-shell` package as most of the tasks can actually be done without it.