### PR TITLE
fix/gulp-fix-symlinks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -214,25 +214,31 @@ gulp.task(unlinkScripts);
 const unlinkTheme = gulp.series(unlinkPatterns, unlinkStyles, unlinkScripts);
 
 const symLinkPatterns = () => {
+  const sourceRelPath = path.relative(`${themeDirectoryPath}/templates`, componentsSourcePath);
+
   return gulp
     .src('.', { allowEmpty: true })
     .pipe(shell([
-      `cd ${themeDirectoryPath}/templates && ln -fs ${componentsSourcePath}`
+      `cd ${themeDirectoryPath}/templates && ln -fs ${sourceRelPath}`
     ]));
 };
 gulp.task(symLinkPatterns);
 
 const symLinkStyles = () => {
+  const sourceRelPath = path.relative(`${themeDirectoryPath}/templates`, componentsSourcePath);
+
   return gulp
     .src('.', { allowEmpty: true })
-    .pipe(shell([`cd ${themeDirectoryPath}/less && ln -fs ${componentsSourcePath}`]));
+    .pipe(shell([`cd ${themeDirectoryPath}/less && ln -fs ${sourceRelPath}`]));
 };
 gulp.task(symLinkStyles);
 
 const symLinkScripts = () => {
+  const sourceRelPath = path.relative(`${themeDirectoryPath}/templates`, componentsSourcePath);
+
   return gulp
     .src('.', { allowEmpty: true })
-    .pipe(shell([`cd ${themeDirectoryPath}/js && ln -fs ${componentsSourcePath}`]));
+    .pipe(shell([`cd ${themeDirectoryPath}/js && ln -fs ${sourceRelPath}`]));
 };
 gulp.task(symLinkScripts);
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -225,7 +225,7 @@ const symLinkPatterns = () => {
 gulp.task(symLinkPatterns);
 
 const symLinkStyles = () => {
-  const sourceRelPath = path.relative(`${themeDirectoryPath}/templates`, componentsSourcePath);
+  const sourceRelPath = path.relative(`${themeDirectoryPath}/less`, componentsSourcePath);
 
   return gulp
     .src('.', { allowEmpty: true })
@@ -234,7 +234,7 @@ const symLinkStyles = () => {
 gulp.task(symLinkStyles);
 
 const symLinkScripts = () => {
-  const sourceRelPath = path.relative(`${themeDirectoryPath}/templates`, componentsSourcePath);
+  const sourceRelPath = path.relative(`${themeDirectoryPath}/js`, componentsSourcePath);
 
   return gulp
     .src('.', { allowEmpty: true })


### PR DESCRIPTION
Gulp task requires source paths to be relative for symlinks to work properly. Turning absolute paths back to relative just for linking fixes the issue.