### PR TITLE
feat/pattern-states

### DIFF
--- a/patternlab-config.json
+++ b/patternlab-config.json
@@ -76,7 +76,8 @@
   "patternStateCascade": [
     "inprogress",
     "inreview",
-    "complete"
+    "complete",
+    "demo"
   ],
   "patternExportAll": false,
   "patternExportDirectory": "pattern_exports",

--- a/source/components/atoms/buttons/buttons.md
+++ b/source/components/atoms/buttons/buttons.md
@@ -1,3 +1,4 @@
 ---
 title: Primary
+state: inprogress
 ---

--- a/source/components/atoms/buttons/buttons~block.md
+++ b/source/components/atoms/buttons/buttons~block.md
@@ -1,3 +1,4 @@
 ---
 title: Block
+state: inprogress
 ---

--- a/source/components/atoms/buttons/buttons~disabled.md
+++ b/source/components/atoms/buttons/buttons~disabled.md
@@ -1,3 +1,4 @@
 ---
 title: Disabled
+state: inprogress
 ---

--- a/source/components/atoms/buttons/buttons~large.md
+++ b/source/components/atoms/buttons/buttons~large.md
@@ -1,3 +1,4 @@
 ---
 title: Large
+state: inprogress
 ---

--- a/source/components/atoms/buttons/buttons~outline.md
+++ b/source/components/atoms/buttons/buttons~outline.md
@@ -1,3 +1,4 @@
 ---
 title: Outline
+state: inprogress
 ---

--- a/source/components/atoms/buttons/buttons~small.md
+++ b/source/components/atoms/buttons/buttons~small.md
@@ -1,3 +1,4 @@
 ---
 title: Small
+state: inprogress
 ---

--- a/source/components/atoms/buttons/buttons~unstyled.md
+++ b/source/components/atoms/buttons/buttons~unstyled.md
@@ -1,3 +1,4 @@
 ---
 title: Unstyled
+state: inprogress
 ---

--- a/source/components/atoms/colors/colors.md
+++ b/source/components/atoms/colors/colors.md
@@ -1,3 +1,4 @@
 ---
 title: Primary
+state: inprogress
 ---

--- a/source/components/atoms/colors/colors~black.md
+++ b/source/components/atoms/colors/colors~black.md
@@ -1,3 +1,4 @@
 ---
 title: Black
+state: inprogress
 ---

--- a/source/components/atoms/colors/colors~info.md
+++ b/source/components/atoms/colors/colors~info.md
@@ -1,3 +1,4 @@
 ---
 title: Info
+state: inprogress
 ---

--- a/source/components/atoms/colors/colors~link.md
+++ b/source/components/atoms/colors/colors~link.md
@@ -1,3 +1,4 @@
 ---
 title: Link
+state: inprogress
 ---

--- a/source/components/atoms/colors/colors~secondary.md
+++ b/source/components/atoms/colors/colors~secondary.md
@@ -1,3 +1,4 @@
 ---
 title: Secondary
+state: inprogress
 ---

--- a/source/components/atoms/colors/colors~warning.md
+++ b/source/components/atoms/colors/colors~warning.md
@@ -1,3 +1,4 @@
 ---
 title: Warning
+state: inprogress
 ---

--- a/source/components/atoms/forms/checkbox-demo.md
+++ b/source/components/atoms/forms/checkbox-demo.md
@@ -1,3 +1,7 @@
+---
+state: demo
+---
+
 #### Description
 
 A general checkbox input which can be a required field.

--- a/source/components/atoms/forms/input/checkbox.md
+++ b/source/components/atoms/forms/input/checkbox.md
@@ -1,3 +1,4 @@
 ---
 hidden: true
+state: inprogress
 ---

--- a/source/components/atoms/forms/input/input-styled.md
+++ b/source/components/atoms/forms/input/input-styled.md
@@ -1,3 +1,4 @@
 ---
 hidden: true
+state: inprogress
 ---

--- a/source/components/atoms/forms/input/input.md
+++ b/source/components/atoms/forms/input/input.md
@@ -1,3 +1,4 @@
 ---
 hidden: true
+state: inprogress
 ---

--- a/source/components/atoms/forms/input/radio.md
+++ b/source/components/atoms/forms/input/radio.md
@@ -1,3 +1,4 @@
 ---
 hidden: true
+state: inprogress
 ---

--- a/source/components/atoms/forms/radio-demo.md
+++ b/source/components/atoms/forms/radio-demo.md
@@ -1,3 +1,7 @@
+---
+state: demo
+---
+
 #### Description
 
 A general radio button.

--- a/source/components/atoms/forms/select-demo.md
+++ b/source/components/atoms/forms/select-demo.md
@@ -1,3 +1,7 @@
+---
+state: demo
+---
+
 #### Description
 
 A general select input element.

--- a/source/components/atoms/forms/select/select.md
+++ b/source/components/atoms/forms/select/select.md
@@ -1,3 +1,4 @@
 ---
 hidden: true
+state: inprogress
 ---

--- a/source/components/atoms/forms/sizing-demo.md
+++ b/source/components/atoms/forms/sizing-demo.md
@@ -1,3 +1,7 @@
+---
+state: demo
+---
+
 #### Description
 
 A styled input text element which can be used to achieve different sized inputs. Input can be a required field.

--- a/source/components/atoms/forms/text-field-demo.md
+++ b/source/components/atoms/forms/text-field-demo.md
@@ -1,3 +1,7 @@
+---
+state: demo
+---
+
 #### Description
 
 A general text input element which can be a required field. Can be used e.g for names, passwords, email addresses and phone numbers.

--- a/source/components/atoms/forms/textarea-demo.md
+++ b/source/components/atoms/forms/textarea-demo.md
@@ -1,3 +1,7 @@
+---
+state: demo
+---
+
 #### Description
 
 A general textarea input element which can be a required field.

--- a/source/components/atoms/forms/textarea/textarea.md
+++ b/source/components/atoms/forms/textarea/textarea.md
@@ -1,3 +1,4 @@
 ---
 hidden: true
+state: inprogress
 ---

--- a/source/components/atoms/forms/touched-demo.md
+++ b/source/components/atoms/forms/touched-demo.md
@@ -1,2 +1,7 @@
+---
+state: demo
+---
+
 #### Description
+
 A general text input and checkbox elements which have specific styling applied to them. Should be preferred in forms to visualise validity of inputs easier.

--- a/source/components/atoms/global/breakpoints.md
+++ b/source/components/atoms/global/breakpoints.md
@@ -1,4 +1,3 @@
 ---
-title: Success
 state: inprogress
 ---

--- a/source/components/atoms/icons/icons.md
+++ b/source/components/atoms/icons/icons.md
@@ -1,3 +1,4 @@
 ---
 title: Font Awesome
+state: inprogress
 ---

--- a/source/components/atoms/icons/icons~custom.md
+++ b/source/components/atoms/icons/icons~custom.md
@@ -1,3 +1,4 @@
 ---
 title: Custom
+state: inprogress
 ---

--- a/source/components/atoms/labels/contextual-variations.md
+++ b/source/components/atoms/labels/contextual-variations.md
@@ -1,4 +1,3 @@
 ---
-title: Success
 state: inprogress
 ---

--- a/source/components/atoms/lists/description/description.md
+++ b/source/components/atoms/lists/description/description.md
@@ -1,3 +1,7 @@
+---
+state: inprogress
+---
+
 #### Description
 
 A general purpose description list component.

--- a/source/components/atoms/lists/holdings/holdings.md
+++ b/source/components/atoms/lists/holdings/holdings.md
@@ -1,3 +1,7 @@
+---
+state: inprogress
+---
+
 #### Description
 
 Holding list component. Used for displaying record availability in different locations.

--- a/source/components/atoms/lists/unordered/unordered.md
+++ b/source/components/atoms/lists/unordered/unordered.md
@@ -1,3 +1,7 @@
+---
+state: inprogress
+---
+
 #### Description
 
 A general unordered list.

--- a/source/components/atoms/tables/ordered/ordered.md
+++ b/source/components/atoms/tables/ordered/ordered.md
@@ -1,3 +1,7 @@
+---
+state: inprogress
+---
+
 #### Description
 
 General ordered table component.

--- a/source/components/atoms/typography/headings.md
+++ b/source/components/atoms/typography/headings.md
@@ -1,4 +1,3 @@
 ---
-title: Success
 state: inprogress
 ---

--- a/source/components/atoms/typography/inline-elements.md
+++ b/source/components/atoms/typography/inline-elements.md
@@ -1,4 +1,3 @@
 ---
-title: Success
 state: inprogress
 ---

--- a/source/components/atoms/typography/paragraph.md
+++ b/source/components/atoms/typography/paragraph.md
@@ -1,4 +1,3 @@
 ---
-title: Success
 state: inprogress
 ---

--- a/source/components/molecules/forms/add-keyword/add-keyword.md
+++ b/source/components/molecules/forms/add-keyword/add-keyword.md
@@ -1,3 +1,7 @@
+---
+state: inprogress
+---
+
 #### Description
 
 Component for adding new keywords to a list of items. Requires Ajax for requests.

--- a/source/components/molecules/media/figure-with-caption/figure-with-caption.md
+++ b/source/components/molecules/media/figure-with-caption/figure-with-caption.md
@@ -1,3 +1,7 @@
+---
+state: inprogress
+---
+
 #### Description
 
 An image with caption text. Caption can be aligned to either left or right.

--- a/source/components/molecules/messaging/alert/alert.md
+++ b/source/components/molecules/messaging/alert/alert.md
@@ -1,5 +1,6 @@
 ---
 title: Alert
+state: inprogress
 ---
 
 #### Description

--- a/source/components/molecules/messaging/alert/alert~error.md
+++ b/source/components/molecules/messaging/alert/alert~error.md
@@ -1,5 +1,6 @@
 ---
 title: Alert Error
+state: inprogress
 ---
 
 #### Description

--- a/source/components/molecules/messaging/alert/alert~success.md
+++ b/source/components/molecules/messaging/alert/alert~success.md
@@ -1,5 +1,6 @@
 ---
 title: Alert Success
+state: inprogress
 ---
 
 #### Description

--- a/source/components/molecules/messaging/alert/alert~warning.md
+++ b/source/components/molecules/messaging/alert/alert~warning.md
@@ -1,5 +1,6 @@
 ---
 title: Alert Warning
+state: inprogress
 ---
 
 #### Description

--- a/source/components/molecules/messaging/in-testing-alert/in-testing-alert.md
+++ b/source/components/molecules/messaging/in-testing-alert/in-testing-alert.md
@@ -1,3 +1,7 @@
+---
+state: inprogress
+---
+
 #### Description
 
 An alert implying that the feature is still in testing and cannot be assumed to work flawlesly at the time. Used exclusively in keywords organism.

--- a/source/components/molecules/navigation/dropdowns/sort.md
+++ b/source/components/molecules/navigation/dropdowns/sort.md
@@ -1,5 +1,6 @@
 ---
 title: Sort dropdown
+state: inprogress
 ---
 
 #### Description

--- a/source/components/molecules/navigation/tabs/demo/tabs-demo.md
+++ b/source/components/molecules/navigation/tabs/demo/tabs-demo.md
@@ -1,3 +1,7 @@
+---
+state: demo
+---
+
 #### Description
 
 General purpose tabs component. Can be used for navigations or showing/hiding content on a single page.

--- a/source/components/molecules/navigation/tabs/demo/tabs-demo~tooltip.md
+++ b/source/components/molecules/navigation/tabs/demo/tabs-demo~tooltip.md
@@ -1,3 +1,7 @@
+---
+state: demo
+---
+
 #### Description
 
 General purpose tabs component with tooltips. Can be used for navigations or showing/hiding content on a single page.

--- a/source/components/molecules/navigation/tabs/demo/tabs-secondary-demo.md
+++ b/source/components/molecules/navigation/tabs/demo/tabs-secondary-demo.md
@@ -1,3 +1,7 @@
+---
+state: demo
+---
+
 #### Description
 
 Secondary level tabs component. Can be used for secondary level navigations or linking on content pages.

--- a/source/components/molecules/navigation/tabs/tabs-secondary.md
+++ b/source/components/molecules/navigation/tabs/tabs-secondary.md
@@ -1,3 +1,4 @@
 ---
 hidden: true
+state: inprogress
 ---

--- a/source/components/molecules/navigation/tabs/tabs.md
+++ b/source/components/molecules/navigation/tabs/tabs.md
@@ -1,3 +1,4 @@
 ---
 hidden: true
+state: inprogress
 ---

--- a/source/components/molecules/tooltips/tooltip/tooltip.md
+++ b/source/components/molecules/tooltips/tooltip/tooltip.md
@@ -1,3 +1,7 @@
+---
+state: inprogress
+---
+
 #### Description
 
 A tooltip element which can be used to show information when user hovers/clicks on a element. Tooltip can be placed on different positions around the triggering element (top, bottom, left, right).

--- a/source/components/organisms/keywords/keywords/keywords.md
+++ b/source/components/organisms/keywords/keywords/keywords.md
@@ -1,3 +1,7 @@
+---
+state: inprogress
+---
+
 #### Description
 
 A keywords component, used for both displaying and editing keywords/tags related to a list of items. The list of items can be a general purpose list for all the users or a customisable list owned by a single user.

--- a/source/components/organisms/navigation/tabs-multi-level/tabs-multi-level.md
+++ b/source/components/organisms/navigation/tabs-multi-level/tabs-multi-level.md
@@ -1,3 +1,7 @@
+---
+state: inprogress
+---
+
 #### Description
 
 Multi level tabs navigation, containing primary and secondary navigations.

--- a/source/components/organisms/navigation/tabs/tabs.md
+++ b/source/components/organisms/navigation/tabs/tabs.md
@@ -1,5 +1,6 @@
 ---
 title: Tabs Main
+state: inprogress
 ---
 
 #### Description

--- a/source/components/organisms/navigation/tabs/tabs~tooltip.md
+++ b/source/components/organisms/navigation/tabs/tabs~tooltip.md
@@ -1,5 +1,6 @@
 ---
 title: Tabs Tooltip
+state: inprogress
 ---
 
 #### Description

--- a/source/styles/patternlab/pattern-scaffolding.css
+++ b/source/styles/patternlab/pattern-scaffolding.css
@@ -329,3 +329,16 @@
 .pl-js-pattern-example {
   position: relative;
 }
+
+.pl-c-pattern-state {
+  height: 0.6em;
+  width: 0.6em;
+}
+
+.pl-c-pattern-state--demo {
+  background-color: #81358a !important;
+}
+
+.pl-c-pattern__header .pl-c-pattern__title {
+  font-size: 1.1rem !important;
+}


### PR DESCRIPTION
Issue [#42](https://github.com/NatLibFi/NDL-VuFind-ui-components/issues/42)
- Add state attribute to patterns
- Add custom state `demo` for demo patterns, for better visual indication of the patterns purpose
- Changes to pattern lab styles, to make the pattern titles slightly easier to read.